### PR TITLE
libinit: Add error handling for unknown regions and models

### DIFF
--- a/libinit/libinit_oplus_sm87xx.cpp
+++ b/libinit/libinit_oplus_sm87xx.cpp
@@ -86,12 +86,24 @@ void SetupModelProperties(const ModelInfo& info, const std::string& region) {
 void vendor_load_properties() {
     std::string buf = "0";
     GetKernelCmdline("oplus_region", &buf);
-
+    
     auto region = std::stoi(buf);
     auto region_suffix_iter = kRegionSuffixMap.find(region);
-
+    
+    // Handle unknown regions gracefully
+    if (region_suffix_iter == kRegionSuffixMap.end()) {
+        LOG(WARNING) << "Unknown oplus_region: " << region << ", using default";
+        region_suffix_iter = kRegionSuffixMap.find(0);
+    }
+    
     auto prjname = std::stoi(GetProperty("ro.boot.prjname", "0"));
     auto model_info = kModelInfoMap.find(prjname);
+    
+    // Handle unknown device models
+    if (model_info == kModelInfoMap.end()) {
+        LOG(ERROR) << "Unknown prjname: " << prjname << ", using default";
+        model_info = kModelInfoMap.find(0);
+    }
 
     SetupModelProperties(model_info->second, region_suffix_iter->second);
 }


### PR DESCRIPTION
Adds fallback to default values when oplus_region or prjname are not found in their respective maps, preventing crashes from dereferencing invalid iterators.

Fixes TWRP boot on devices with unsupported region codes, including global OnePlus 13 (oplus_region 167).

Tested on global OnePlus 13.