### PR TITLE
Add OnePlus Pad 2 Pro (OPD2413) support

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,6 +11,7 @@
 - Realme GT8 (CN)
 - OnePlus Ace 6 (CN)
 - OnePlus Turbo 6 (CN)
+- OnePlus Pad 2 Pro (CN)
 
 ## Build it yourself?
 

--- a/libinit/libinit_oplus_sm87xx.cpp
+++ b/libinit/libinit_oplus_sm87xx.cpp
@@ -116,7 +116,7 @@ void vendor_load_properties() {
     if (prjname == 24926) {
         OverrideProperty("persist.twrp.rotation", "270");
     }
-    // Set a prop to handle rotation
+    // Set a prop to handle strongbox
     switch (prjname) {
         case 24851:
             OverrideProperty("twrp.se.no_sb", "true");

--- a/libinit/libinit_oplus_sm87xx.cpp
+++ b/libinit/libinit_oplus_sm87xx.cpp
@@ -48,6 +48,7 @@ const std::unordered_map<int, ModelInfo> kModelInfoMap = {
     {24875, {"OnePlus", "OP612BL1", "OnePlus", "CPH2723", "CPH2723", "OnePlus_13_s",        "1"}}, // pagani IN
     {24851, {"OnePlus", "OP6113L1", "OnePlus", "PLQ110",  "PLQ110",  "OnePlus_ACE_6",       "0"}}, // ktm CN
     {25600, {"realme",  "RE6400L1", "realme",  "RMX6699", "RMX6699", "Realme_GT_8",         "0"}}, // RMX6699 CN
+    {24926, {"OnePlus", "OP615EL1", "OnePlus", "OPD2413", "OPD2413", "OnePlus_Pad2Pro",     "0"}}, // ossi CN
     {0,     {"OPLUS",   "SM87XX",   "OPLUS",   "SM87XX",  "SM87XX",  "SM87XX",              "0"}}, // Default
 };
 
@@ -111,7 +112,11 @@ void vendor_load_properties() {
 
     SetupModelProperties(model_info->second, region_suffix_iter->second);
 
-    // Set a prop to handle strongbox
+    // Set a prop to handle rotation
+    if (prjname == 24926) {
+        OverrideProperty("persist.twrp.rotation", "270");
+    }
+    // Set a prop to handle rotation
     switch (prjname) {
         case 24851:
             OverrideProperty("twrp.se.no_sb", "true");


### PR DESCRIPTION
## Issue
#16 

## Device information

Device properties were collected using the following command:

```bash
adb shell 'echo "brand=$(getprop ro.product.brand) device=$(getprop ro.product.device) manufacturer=$(getprop ro.product.manufacturer) model=$(getprop ro.product.model) base_name=$(getprop ro.product.name | cut -d_ -f1) prjname=$(getprop ro.boot.prjname)"'
```

Output:

```
brand=OnePlus device=OP615EL1 manufacturer=OnePlus model=OPD2413 base_name=OPD2413 prjname=24926
```

| Field | Value |
|---|---|
| Brand | OnePlus |
| Device | OP615EL1 |
| Model | OPD2413 |
| Project number (prjname) | 24926 |
| SoC | Snapdragon 8 Elite (sm87xx) |

## Changes

**`README.md`**

Add OnePlus Pad 2 Pro (CN) to the supported devices list.

**`libinit/libinit_oplus_sm87xx.cpp`**

1. Add a new entry for OnePlus Pad 2 Pro in `kModelInfoMap` (prjname `24926`), so that libinit can correctly identify the device at recovery boot and set the appropriate brand, model, and related properties.

2. Add rotation handling: since OnePlus Pad 2 Pro is a tablet, its natural screen orientation differs from phones. `persist.twrp.rotation` is set to `270` for this device and `0` for all others.

## Testing (tested on OnePlus Pad 2 Pro)

- [x] ADB
- [x] Display (correct rotation)
- [x] Decryption
- [x] Fastbootd
- [x] Flashing
- [x] MTP
- [x] Sideload
- [x] Touch
- [x] USB OTG
- [ ] ❌ Vibrator (OnePlus Pad 2 Pro has no vibration motor, expected)
